### PR TITLE
Libellé pour le formulaire de soumission Papyrus TME

### DIFF
--- a/src/themes/papyrus/assets/i18n/fr.json5
+++ b/src/themes/papyrus/assets/i18n/fr.json5
@@ -63,4 +63,7 @@
   "search.filters.filter.affiliation.head": "Affiliation",
   "search.filters.filter.affiliation.placeholder": "Nom de l'affiliation",
   "search.filters.filter.affiliation.label": "Recherche d'une affiliation",
+
+  // Les intitués de section des formulaires de soumission
+  "submission.sections.papyrus-TME.page-01": "Décrire",
 }


### PR DESCRIPTION
Ajout d'un libellé pour l'intitulé d'une section dans le formulaire de soumission Papyrus TME. Simplement pour être cohérent. Pas de test à faire.