### PR TITLE
Ajout d'un libellé pour la fenêtre des vocabulaires contrôlés

### DIFF
--- a/src/themes/papyrus/assets/i18n/fr.json5
+++ b/src/themes/papyrus/assets/i18n/fr.json5
@@ -74,4 +74,6 @@
   "submission.sections.papyrus-PE.page-01": "Type de document",
   "submission.sections.papyrus-PE.page-02": "Description du document",
 
+  "vocabulary-treeview.info": "Faites une recherche puis sélectionner un terme à insérer",
+
 }


### PR DESCRIPTION
Un simple petit libellé en français pour inciter l'usager à rechercher des termes.

Compiler et exécuter.